### PR TITLE
feat: Adding async and poll to unarchive task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   when:
     - version_file.stat.exists | default(false)
 
-- name: Download toolchain
+- name: Download toolchain from {{ toolchain_url }}
   become: true
   unarchive:
     creates: "{{ toolchain_creates_directory | default(omit) }}"
@@ -26,6 +26,8 @@
     list_files: true
     remote_src: true
     src: "{{ toolchain_url }}"
+  async: "{{ toolchain_async | default(omit) }}"
+  poll: "{{ toolchain_poll | default(omit) }}"
   register: toolchain_archive_contents
   when:
     - version_value.stdout | default("none") != toolchain_version


### PR DESCRIPTION
Add options to specify async and poll. This is to allow the user to define how long a toolchain download should take and to more efficiently move on to the next task. This is an optional feature.

Also added toolchain_url to the name of the task in order to be able to differentiate which toolchain is being downloaded