### PR TITLE
fix: Fixing conditional to check version file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,8 @@
   register: version_value
   changed_when: false
   when:
+    - final_dest.stat.exists
+    - version_file is defined
     - version_file.stat.exists | default(false)
 
 - name: Download toolchain from {{ toolchain_url }}


### PR DESCRIPTION
Older versions of Ansible don't seem to handle undefinied variables with
default values well.