### PR TITLE
fix: Check version before deleting old toolchain

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,9 @@
   file:
     path: "{{ toolchain_final_dest }}"
     state: absent
-  when: toolchain_delete_old_final_dest
+  when:
+    - toolchain_delete_old_final_dest
+    - version_value.stdout | default("none") != toolchain_version
 
 - name: Download toolchain from {{ toolchain_url }}
   become: true


### PR DESCRIPTION
### Description

This will allow child roles to be idempotent.

Previously, the role would delete the toolchain, even if the correct version is installed.