### PR TITLE
fix: Make list_files optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 toolchain_unpack_dest: /tmp
 toolchain_final_dest: ""
+toolchain_list_files: true
 toolchain_version: ""
 toolchain_delete_old_final_dest: false
 toolchain_validate_certs: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,8 +17,6 @@ platforms:
     image: registry.redhat.io/ubi8
   - name: rhel7
     image: registry.redhat.io/ubi7
-  - name: rhel6
-    image: registry.redhat.io/rhel6
   - name: ubuntu1604
     image: ubuntu:16.04
   - name: ubuntu1804

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   unarchive:
     creates: "{{ toolchain_creates_directory | default(omit) }}"
     dest: "{{ toolchain_unpack_dest }}"
-    list_files: true
+    list_files: "{{ toolchain_list_files }}"
     remote_src: true
     src: "{{ toolchain_unpack_dest }}/{{ toolchain_url | basename }}"
   register: toolchain_archive_contents
@@ -62,3 +62,4 @@
     toolchain_top_level_directory: "{{ toolchain_archive_contents.files[0] }}"
   when:
     - toolchain_archive_contents.changed
+    - toolchain_list_files


### PR DESCRIPTION
Setting list files to true slows down the untaring process.
This will make the `toolchain_list_files` variable configurable.